### PR TITLE
Fix for php7.2

### DIFF
--- a/lib/message.php
+++ b/lib/message.php
@@ -34,7 +34,7 @@
             while (list ($key, $val) = each ($request)) {
                 $arg.=$key."=".$val."&";
             }
-            $arg = substr($arg,0,count($arg)-2);
+            $arg = rtrim($arg,"&");
             if(get_magic_quotes_gpc()){$arg = stripslashes($arg);}
             
             if($this->signType=='sha1'){


### PR DESCRIPTION
php sdk中message::buildSignature在php7.2下报错（5.6下正常）。 
PHP Warning: count(): Parameter must be an array or an object that implements Countable in ... 
根据定义，改为$arg = rtrim($arg,"&");可解决。
在php5.6和php7.2下均测试通过